### PR TITLE
Fix compile error on MacOS (Darwin)

### DIFF
--- a/src/ppl/common/log.cc
+++ b/src/ppl/common/log.cc
@@ -92,8 +92,12 @@ DEF_READ_OPERATOR_FUNC(uint32_t, "%u");
 DEF_READ_OPERATOR_FUNC(int64_t, "%ld");
 DEF_READ_OPERATOR_FUNC(uint64_t, "%lu");
 
+#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
+DEF_READ_OPERATOR_FUNC(size_t, "%lu");
+#else
 DEF_READ_OPERATOR_FUNC(long long, "%lld");
 DEF_READ_OPERATOR_FUNC(unsigned long long, "%llu");
+#endif
 
 DEF_READ_OPERATOR_FUNC(const void*, "%p");
 

--- a/src/ppl/common/log.h
+++ b/src/ppl/common/log.h
@@ -68,8 +68,12 @@ public:
     LogMessage& operator<<(int64_t i64);
     LogMessage& operator<<(uint64_t u64);
 
+#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
+    LogMessage& operator<<(size_t s);
+#else
     LogMessage& operator<<(long long ll);
     LogMessage& operator<<(unsigned long long ull);
+#endif
 
     LogMessage& operator<<(const char*);
     LogMessage& operator<<(const std::string&);

--- a/src/ppl/common/x86/sysinfo.cc
+++ b/src/ppl/common/x86/sysinfo.cc
@@ -230,7 +230,7 @@ testIsaAVX512() {
 //}
 
 static void GetCacheInfo(const int &eax, const int &ebx, const int &ecx, const int &edx,
-                        size_t* cache_size, bool* inclusive) {
+                        uint64_t* cache_size, bool* inclusive) {
     int cache_type = eax & 31;
     if (cache_type == 0) {
         *cache_size = 0;
@@ -243,7 +243,7 @@ static void GetCacheInfo(const int &eax, const int &ebx, const int &ecx, const i
         int cacheline_size = (ebx & 0xfff) + 1;
         int cacheline_partitions = ((ebx >> 12) & 0x3ff) + 1;
         int cache_ways = ((ebx >> 22) & 0x3ff) + 1;
-        *cache_size = static_cast<size_t>(cache_ways * cacheline_partitions * cacheline_size * cache_sets);
+        *cache_size = static_cast<uint64_t>(cache_ways * cacheline_partitions * cacheline_size * cache_sets);
         if (inclusive != nullptr) {
             *inclusive = (edx >> 1) & 1;
         }


### PR DESCRIPTION
Some C++ 17 feature not supported in MacOS clang (Darwin), this PR contains some fix specify on Darwin.
Related to [issue](https://github.com/openppl-public/ppl.nn/pull/20) in ppl.nn.