### PR TITLE
[fix] add judgment on avx512

### DIFF
--- a/src/ppl/common/x86/sysinfo.cc
+++ b/src/ppl/common/x86/sysinfo.cc
@@ -162,7 +162,7 @@ float TestIsaFMA()
 
 // About __AVX512F__ see: https://docs.microsoft.com/en-us/cpp/build/reference/arch-x64?view=vs-2019
 // AVX512 was landed in VS2017 and GCC-4.9.2
-#if (GCC_VERSION >= 40902 || _MSC_VER >= 1910)
+#if defined(__AVX512F__) && (GCC_VERSION >= 40902 || _MSC_VER >= 1910)
 static float
 #ifdef __GNUC__
 __attribute__((__target__("avx512f"))) __attribute__((optimize(0)))
@@ -275,7 +275,7 @@ void GetCPUInfoByCPUID(struct CpuInfo* info) {
 }
 
 void GetCPUInfoByRun(CpuInfo* info) {
-#if (GCC_VERSION >= 40902 || _MSC_VER >= 1910)
+#if defined(__AVX512F__) && (GCC_VERSION >= 40902 || _MSC_VER >= 1910)
     if (0 == try_run(&TestIsaAVX512)) {
         info->isa |= ISA_X86_AVX512;
     }


### PR DESCRIPTION
I encountered the following error when compiling ppl.nn x86 on WSL linux

<img width="1605" alt="996aff2c4e7e9173aee48f5d9ca81c60" src="https://github.com/openppl-public/ppl.common/assets/45321964/f6ad0ad6-4e63-4a8f-97f5-5f5ed6aee7f5">

I modified the code in ppl.common and the problem was fixed.